### PR TITLE
Allow data migrations to be reverted

### DIFF
--- a/lib/migration.ex
+++ b/lib/migration.ex
@@ -14,16 +14,22 @@ defmodule EctoImmigrant.Migration do
         alias ExampleApp.Person
 
         def up do
-          Repo.insert(%Person{first_name: "John", last_name: "Doe", age: 78})
+          Repo.insert(%Person{id: 123, first_name: "John", last_name: "Doe", age: 78})
+        end
+
+        def down do
+          Repo.delete(%Person{id: 123, first_name: "John", last_name: "Doe", age: 78})
         end
       end
 
-  Note data migrations have only an `up/0`, which is used to update your data.
+  Note data migrations have an `up/0` and `down/0`, which is used to update your data
+  and reverts the updated data, respectively.
 
   EctoImmigrant provides some mix tasks to help developers work with migrations:
 
     * `mix ecto_immigrant.gen.migration` # Generates a new data migration for the repo
     * `mix ecto_immigrant.migrate`       # Runs the repository data migrations
+    * `mix ecto_immigrant.rollback`      # Reverts applied data migrations from the repository
     * `mix ecto_immigrant.migrations`    # Displays the repository data migration status
 
   Run the `mix help COMMAND` for more information.
@@ -46,7 +52,11 @@ defmodule EctoImmigrant.Migration do
         alias ExampleApp.Person
 
         def up do
-          Repo.insert(%Person{first_name: "John", last_name: "Doe", age: 78})
+          Repo.insert(%Person{id: 123, first_name: "John", last_name: "Doe", age: 78})
+        end
+
+        def down do
+          Repo.delete(%Person{id: 123, first_name: "John", last_name: "Doe", age: 78})
         end
       end
 

--- a/lib/mix/tasks/ecto_immigrant.gen.migration.ex
+++ b/lib/mix/tasks/ecto_immigrant.gen.migration.ex
@@ -85,6 +85,10 @@ defmodule Mix.Tasks.EctoImmigrant.Gen.Migration do
     def up do
   <%= @change %>
     end
+
+    def down do
+  <%= @change %>
+    end
   end
   """)
 end

--- a/lib/mix/tasks/ecto_immigrant.rollback.ex
+++ b/lib/mix/tasks/ecto_immigrant.rollback.ex
@@ -1,0 +1,89 @@
+defmodule Mix.Tasks.EctoImmigrant.Rollback do
+  use Mix.Task
+  import Mix.Ecto
+  import Mix.EctoImmigrant
+
+  @shortdoc "Roll backs the repository data migrations"
+
+  @moduledoc """
+  Reverts applied data migrations for the given repository.
+
+  Data migrations are expected at "priv/YOUR_REPO/data_migrations" directory
+  of the current application, where "YOUR_REPO" is the last segment
+  in your repository name. For example, the repository `MyApp.Repo`
+  will use "priv/repo/data_migrations". The repository `Whatever.MyRepo`
+  will use "priv/my_repo/data_migrations".
+
+  This task rolls back the last applied data migrations by default.
+
+  If a repository has not yet been started, one will be started outside
+  your application supervision tree and shutdown afterwards.
+
+  ## Examples
+
+      mix ecto_immigrant.rollback
+      mix ecto_immigrant.rollback -r Custom.Repo
+
+      mix ecto_immigrant.rollback -n 3
+      mix ecto_immigrant.rollback --step 3
+
+      mix ecto_immigrant.rollback --to 20080906120000
+
+  ## Command line options
+
+    * `-r`, `--repo` - the repo to rollback
+
+    * `--all` - revert all applied migrations
+
+    * `--step`, `-n` - revert n number of applied migrations
+
+    * `--to` - revert all migrations down to and including version
+
+    * `--quiet` - do not log migration commands
+
+    * `--prefix` - the prefix to run migrations on
+
+    * `--log-sql` - log the raw sql migrations are running
+  """
+
+  @aliases [
+    r: :repo,
+    n: :step
+  ]
+
+  @switches [
+    all: :boolean,
+    step: :integer,
+    to: :integer,
+    quiet: :boolean,
+    prefix: :string,
+    log_sql: :boolean,
+    repo: [:keep, :string]
+  ]
+
+  @doc false
+  def run(args, migrator \\ &EctoImmigrant.Migrator.run/4) do
+    repos = parse_repo(args)
+    {opts, _} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
+
+    opts =
+      if opts[:to] || opts[:step] || opts[:all],
+        do: opts,
+        else: Keyword.put(opts, :step, 1)
+
+    for repo <- repos do
+      ensure_repo(repo, args)
+      ensure_data_migrations_path(repo)
+      Mix.Task.run("app.start")
+      repo.start_link(opts)
+
+      pool = repo.config[:pool]
+
+      if function_exported?(pool, :unboxed_run, 2) do
+        pool.unboxed_run(repo, fn -> migrator.(repo, data_migrations_path(repo), :down, opts) end)
+      else
+        migrator.(repo, data_migrations_path(repo), :down, opts)
+      end
+    end
+  end
+end

--- a/test/mix/tasks/ecto_immigrant.rollback_test.exs
+++ b/test/mix/tasks/ecto_immigrant.rollback_test.exs
@@ -1,0 +1,130 @@
+defmodule Mix.Tasks.EctoImmigrant.RollbackTest do
+  use ExUnit.Case
+
+  import Mix.Tasks.EctoImmigrant.Rollback, only: [run: 2]
+  import Support.FileHelpers
+
+  @migrations_path Path.join([tmp_path(), inspect(EctoImmigrant.Migrate), "data_migrations"])
+
+  setup do
+    File.mkdir_p!(@migrations_path)
+    :ok
+  end
+
+  defmodule Repo do
+    def start_link(_) do
+      Process.put(:started, true)
+
+      Task.start_link(fn ->
+        Process.flag(:trap_exit, true)
+
+        receive do
+          {:EXIT, _, :normal} -> :ok
+        end
+      end)
+    end
+
+    def stop(_pid) do
+      :ok
+    end
+
+    def __adapter__ do
+      EctoImmigrant.TestAdapter
+    end
+
+    def config do
+      [priv: "tmp/#{inspect(EctoImmigrant.Migrate)}", otp_app: :ecto_immigrant]
+    end
+  end
+
+  defmodule StartedRepo do
+    def start_link(_) do
+      Process.put(:already_started, true)
+      {:error, {:already_started, :whatever}}
+    end
+
+    def stop(_) do
+      raise "should not be called"
+    end
+
+    def __adapter__ do
+      EctoImmigrant.TestAdapter
+    end
+
+    def config do
+      [priv: "tmp/#{inspect(EctoImmigrant.Migrate)}", otp_app: :ecto_immigrant]
+    end
+  end
+
+  test "runs the migrator with app_repo config" do
+    Application.put_env(:ecto_immigrant, :ecto_repos, [Repo])
+
+    run([], fn _, _, _, _ ->
+      Process.put(:migrated, true)
+      []
+    end)
+
+    assert Process.get(:migrated)
+    assert Process.get(:started)
+  after
+    Application.delete_env(:ecto, :ecto_repos)
+  end
+
+  test "runs the migrator after starting repo" do
+    run(["-r", to_string(Repo)], fn _, _, _, _ ->
+      Process.put(:migrated, true)
+      []
+    end)
+
+    assert Process.get(:migrated)
+    assert Process.get(:started)
+  end
+
+  test "runs the migrator with the already started repo" do
+    run(["-r", to_string(StartedRepo)], fn _, _, _, _ ->
+      Process.put(:migrated, true)
+      []
+    end)
+
+    assert Process.get(:migrated)
+    assert Process.get(:already_started)
+  end
+
+  test "runs the migrator with two repos" do
+    run(["-r", to_string(Repo), "-r", to_string(StartedRepo)], fn _, _, _, _ ->
+      Process.put(:migrated, true)
+      []
+    end)
+
+    assert Process.get(:migrated)
+    assert Process.get(:started)
+    assert Process.get(:already_started)
+  end
+
+  test "runs the migrator yielding the repository and migrations path" do
+    run(["-r", to_string(Repo), "--quiet", "--prefix", "foo"], fn repo, path, direction, opts ->
+      assert repo == Repo
+
+      assert path ==
+               Path.expand("tmp/#{inspect(EctoImmigrant.Migrate)}/data_migrations", File.cwd!())
+
+      assert direction == :down
+      assert opts[:step] == 1
+      refute opts[:all]
+      refute opts[:to]
+      []
+    end)
+
+    assert Process.get(:started)
+  end
+
+  test "raises when data migrations path does not exist" do
+    File.rm_rf!(@migrations_path)
+
+    assert_raise Mix.Error, fn ->
+      run(["-r", to_string(Repo)], fn _, _, _, _ -> [] end)
+    end
+
+    assert !Process.get(:started)
+  end
+end


### PR DESCRIPTION
Hello!

I made some changes to allow the `:down` direction with your library. This PR allows users to use the mix task `ecto_immigrant.rollback` and, with a release version, runs `EctoImmigrant.Migrator.run/4`.

```elixir
for repo <- Application.fetch_env!(:my_app, :ecto_repos) do
  path = Application.app_dir(:my_app, "priv/#{Macro.camelize(repo)}/data_migrations")
  EctoImmigrant.Migrator.run(repo, path, :down, step: 1)
end
```

I used the `example_app` for testing with the docs from `EctoImmigrant.Migration` module.

Feel free to do changes if u want to.

Closes #4.